### PR TITLE
docs: ADR-010 + PRP sprint-12 — STT fallback for inbound audio

### DIFF
--- a/PRPs/sprint-12-stt-fallback.md
+++ b/PRPs/sprint-12-stt-fallback.md
@@ -1,0 +1,407 @@
+# PRP: Sprint 12 — STT fallback for inbound audio
+
+> **Version:** 1.0
+> **Created:** 2026-06-15
+> **Status:** Draft
+> **Tracks:** chasqui#15 (STT fallback for audio).
+> **Decisions to record:** ADR-010 (opt-in STT, gated on `caps.audio=False`;
+> one OpenAI-compatible client, **Groq default** for native OGG/Opus + cost;
+> separate `STT_API_KEY`; graceful degradation preserved).
+
+---
+
+## Goal
+
+When a contact sends a **voice note** and the configured LLM **can't hear**
+(`caps.audio = False` — Anthropic, plain OpenAI GPT, most of the registry),
+**transcribe the audio before the turn** so the agent answers its content as if
+it were text. Today that case dead-ends in a graceful *"please type it"* fallback
+(`orchestrator._current_message`). Native-audio models (Gemini) are unaffected —
+they keep getting the audio block directly.
+
+End state: an **opt-in** STT step (`STT_PROVIDER` set) that, for audio + an
+audio-less LLM, calls an **OpenAI-compatible** transcription endpoint
+(**Groq `whisper-large-v3-turbo`** by default — native OGG/Opus, ~$0.00067/min),
+sets the inbound's text to the transcript, and lets the existing turn machinery
+render it. Disabled or failing → **exactly today's** graceful fallback. STT never
+breaks a turn.
+
+## Why
+
+- **Voice notes are first-class on messaging.** On WhatsApp/Telegram a huge share
+  of inbound is audio. With an audio-less LLM the agent is currently useless for
+  it — it can only ask the user to retype.
+- **Cheap, well-understood, opt-in.** Transcription is a solved, sub-cent step.
+  Gating it behind `STT_PROVIDER` keeps the default install unchanged.
+- **The format constraint forces the provider choice (ADR-010).** WhatsApp/
+  Telegram voice is **OGG/Opus**; OpenAI's transcription API doesn't list OGG, so
+  it would need ffmpeg. **Groq lists OGG natively** and is the cheapest — so it's
+  the default, via a client that also speaks OpenAI by swapping `STT_BASE_URL`.
+- **It's the last open issue** for the v0.2.x audio story (native audio shipped
+  with the multimodal turn; this completes the matrix for non-audio models).
+
+## What
+
+One new service + a pre-turn hook, gated by one env var:
+
+1. **A transcription service** (`app/services/transcription.py`): `httpx`
+   multipart `POST {base_url}/audio/transcriptions`, `response_format=text`.
+   `stt_enabled()` + `async transcribe(audio: bytes, mime: str) -> str | None`.
+2. **A pre-turn STT pass** in the orchestrator: for an `audio` inbound, when
+   `not caps.audio` and STT is enabled and media bytes are present, transcribe and
+   set `inbound.text` to the transcript. Runs in **both** turn paths (synchronous
+   `run_turn` and coalesced `run_coalesced_turn`).
+3. **Render the transcript** in `_current_message`'s audio `else` branch as a
+   voice-message turn (no audio content block — the LLM can't take one).
+
+**Escape hatch / default:** `STT_PROVIDER=""` (default) ⇒ disabled ⇒ today's
+exact graceful fallback. No new dependency, no behavior change for anyone who
+doesn't opt in.
+
+### Success Criteria
+- [ ] Audio inbound + audio-less LLM + STT enabled → transcript reaches the agent
+      as a Human turn; the reply addresses the spoken content.
+- [ ] Native-audio LLM (Gemini) path **unchanged** — never calls STT.
+- [ ] STT disabled (`STT_PROVIDER=""`) → byte-for-byte today's graceful fallback.
+- [ ] STT error/timeout/oversize → graceful fallback (turn never fails); logged.
+- [ ] Works in **both** turn paths: synchronous and coalesced (ADR-008,
+      media re-hydrated from the bucket).
+- [ ] Default provider Groq `whisper-large-v3-turbo`, OGG sent as-is (no
+      transcoding); OpenAI selectable via `STT_BASE_URL`/`STT_MODEL`.
+- [ ] `STT_API_KEY` is separate from the LLM key; required only when enabled.
+- [ ] ADR-010 written; ARCHITECTURE updated (audio degradation now has an STT
+      branch); `.env.example` + READMEs/AGENTS reflect STT; CLI wizard opt-in
+      (cross-repo) tracked.
+
+---
+
+## All Needed Context
+
+### Documentation & References
+```yaml
+- file: docs/design/adr-010-stt-audio-fallback.md
+  why: the decision this PRP implements (provider choice, gating, key separation)
+- file: core/app/services/orchestrator.py
+  why: _current_message (audio branch ~154-177) is the degradation point; run_turn
+       (~237) and run_coalesced_turn (~282) are the two hooks; _parse_data_uri
+       (~110) + _message_to_inbound (~260) give the media bytes
+- file: core/app/core/llm_capabilities.py
+  why: caps.audio — STT runs only when False (resolve_capabilities)
+- file: core/app/core/config.py
+  why: add stt_* settings (mirror the openai_base_url pattern at line 41)
+- file: core/app/services/channel_send.py
+  why: the httpx.AsyncClient pattern to mirror (timeout, error mapping) ~87-96
+- file: core/app/core/storage.py
+  why: audio/ogg → ogg mapping (~36) confirms inbound mime; get_media for bytes
+- url: https://console.groq.com/docs/speech-to-text
+  why: default provider — models, ogg in supported formats, OpenAI-compatible
+       endpoint api.groq.com/openai/v1/audio/transcriptions, 25MB cap
+- url: https://platform.openai.com/docs/api-reference/audio/createTranscription
+  why: the de-facto multipart shape (model, file, response_format) — same on Groq
+```
+
+### Current flow (graceful degradation, today)
+```
+audio inbound → _current_message(inbound, caps):
+   if caps.audio and media:            # Gemini → native audio block
+       HumanMessage([text, {audio block}])
+   else:                               # ← audio-less LLM dead-ends here
+       HumanMessage("[voice message you cannot listen to. Ask them to write it.]")
+```
+
+### Desired flow (STT enabled, audio-less LLM)
+```
+audio inbound → run_turn / run_coalesced_turn:
+   inbound = await _transcribe_if_needed(inbound, caps)     # ← new pre-turn pass
+        # only when: inbound.type=="audio" and not caps.audio
+        #            and stt_enabled() and media bytes present
+        # success → inbound.text = transcript
+        # error/oversize/timeout → inbound unchanged (logged)
+   _current_message(inbound, caps):
+       if caps.audio and media: ...native...                # unchanged
+       else:
+           if inbound.text:                                 # ← transcript (or caption)
+               HumanMessage('voice message; transcript: "<text>". Respond naturally...')
+           else:
+               HumanMessage("[voice message ... ask them to write it]")   # unchanged
+```
+
+### Known gotchas & conventions
+```python
+# 1. caps.audio gate is mandatory. NEVER transcribe when caps.audio is True —
+#    Gemini answers audio better natively and it'd be wasted spend. STT is the
+#    NON-audio path only.
+
+# 2. _current_message is SYNC; transcription is async (httpx). Do STT as an async
+#    PRE-PASS that returns a (possibly) modified InboundMessage, then call the
+#    sync _current_message. Do NOT try to await inside _current_message.
+
+# 3. Media bytes: _parse_data_uri returns (mime, b64_str). base64.b64decode it to
+#    bytes for the multipart 'file'. In the coalesced path media is re-hydrated by
+#    _message_to_inbound (ADR-008/003); if storage is unset there are no bytes →
+#    STT can't run → graceful fallback (same as native-audio-without-storage).
+
+# 4. OGG goes to Groq AS-IS — no transcoding. Send filename "audio.ogg" + the
+#    real mime in the multipart so the provider's sniffer is happy. For OpenAI
+#    (no OGG support) that's the operator's caveat (ADR-010), not our problem.
+
+# 5. STT failure is NEVER fatal. Wrap the call: any httpx/timeout/HTTP-error/
+#    oversize → log a warning, return None → inbound unchanged → existing text
+#    fallback. Mirror channel_send / notify_service best-effort posture.
+
+# 6. 25MB cap (Groq free tier). Guard: if len(bytes) > STT_MAX_BYTES → skip + log
+#    (voice notes are tiny; this is the pathological guard only).
+
+# 7. Separate credential. STT_API_KEY is independent of the LLM key (the whole
+#    point is LLM != audio provider). If STT_PROVIDER set but STT_API_KEY empty →
+#    log once at startup and treat STT as disabled (don't 500 mid-turn).
+
+# 8. response_format=text returns a plain-text body (not JSON) — read response.text,
+#    strip. (json mode returns {"text": ...}; text mode is simpler.)
+
+# 9. No new dependency: httpx is already in pyproject. Do NOT add the openai or
+#    groq SDK.
+```
+
+---
+
+## Implementation Blueprint
+
+### Config (`app/core/config.py`)
+```python
+# Speech-to-text fallback (ADR-010). Transcribe inbound audio when the LLM lacks
+# native audio input (caps.audio False). Empty provider = DISABLED → the existing
+# graceful "ask for text" fallback. OpenAI-compatible API; Groq default (native
+# OGG/Opus, cheapest). The credential is SEPARATE from the LLM key on purpose.
+stt_provider: str = ""            # "" disabled | "groq" | "openai" | "<compatible>"
+stt_base_url: str | None = None   # default derived from provider when empty
+stt_model: str = "whisper-large-v3-turbo"
+stt_api_key: str | None = None    # required when enabled; not the LLM key
+stt_language: str | None = None   # ISO-639-1 hint; empty = auto-detect
+stt_timeout_seconds: float = 30.0
+stt_max_bytes: int = 25 * 1024 * 1024  # provider request cap (Groq free tier)
+
+# provider → default base_url (an explicit stt_base_url overrides):
+#   groq   → https://api.groq.com/openai/v1
+#   openai → https://api.openai.com/v1
+```
+
+### Transcription service (`app/services/transcription.py`, new)
+```python
+_DEFAULT_BASE_URLS = {
+    "groq": "https://api.groq.com/openai/v1",
+    "openai": "https://api.openai.com/v1",
+}
+
+def stt_enabled() -> bool:
+    return bool(settings.stt_provider and settings.stt_api_key)
+
+def _base_url() -> str:
+    return (settings.stt_base_url
+            or _DEFAULT_BASE_URLS.get(settings.stt_provider, "")).rstrip("/")
+
+async def transcribe(audio: bytes, mime: str) -> str | None:
+    """Best-effort transcription. None on any failure (caller falls back)."""
+    if not stt_enabled() or not _base_url():
+        return None
+    if len(audio) > settings.stt_max_bytes:
+        logger.warning("Audio %d bytes over STT cap — skipping transcription", len(audio))
+        return None
+    ext = storage.ext_for_mime(mime) or "ogg"           # reuse storage map
+    files = {"file": (f"audio.{ext}", audio, mime)}
+    data = {"model": settings.stt_model, "response_format": "text"}
+    if settings.stt_language:
+        data["language"] = settings.stt_language
+    headers = {"Authorization": f"Bearer {settings.stt_api_key}"}
+    try:
+        async with httpx.AsyncClient(timeout=settings.stt_timeout_seconds) as client:
+            r = await client.post(f"{_base_url()}/audio/transcriptions",
+                                  data=data, files=files, headers=headers)
+            r.raise_for_status()
+    except httpx.HTTPError as exc:
+        logger.warning("STT request failed (%s) — text fallback", exc)
+        return None
+    text = r.text.strip()
+    return text or None
+```
+
+### Orchestrator hook (`app/services/orchestrator.py`)
+```python
+async def _transcribe_if_needed(inbound: InboundMessage,
+                                caps: ModelCapabilities) -> InboundMessage:
+    """STT pre-pass: audio + audio-less LLM + STT on → set inbound.text."""
+    if inbound.type != "audio" or caps.audio or not transcription.stt_enabled():
+        return inbound
+    media = _parse_data_uri(inbound.media_url)
+    if not media:
+        return inbound
+    mime, b64 = media
+    transcript = await transcription.transcribe(base64.b64decode(b64), mime)
+    if not transcript:
+        return inbound
+    logger.info("STT transcribed inbound audio (%d chars)", len(transcript))
+    return inbound.model_copy(update={"text": transcript})  # keep type="audio"
+
+# run_turn: before building messages
+inbound = await _transcribe_if_needed(inbound, caps)
+# (caps already computed via _capabilities(); compute it once and pass down)
+
+# run_coalesced_turn: map the pass over each inbound in the batch
+#   batch_inbounds = [await _transcribe_if_needed(_message_to_inbound(m)..., caps) ...]
+
+# _current_message audio else-branch becomes:
+else:
+    if inbound.text:   # STT transcript (or a rare audio caption)
+        return HumanMessage(
+            f'The user sent a voice message. Transcript: "{inbound.text}". '
+            "Respond to its content naturally. Do NOT say you transcribed it."
+        )
+    return HumanMessage(
+        "[The user sent a voice message you cannot listen to. "
+        "Kindly ask them to write it as text.]"
+    )
+```
+
+### Tasks (in execution order)
+```yaml
+Task 0 (GATE — do first): verify Groq accepts a real WhatsApp OGG/Opus voice note
+  - curl a captured .ogg to api.groq.com/openai/v1/audio/transcriptions with
+    whisper-large-v3-turbo, response_format=text. Expect 200 + transcript.
+  - This validates ADR-010's core premise (native OGG) before writing code.
+    (If it failed, ADR-010's ffmpeg follow-up would re-open — not expected.)
+
+Task 1: Config
+  - MODIFY: core/app/core/config.py (stt_* settings above)
+  - MODIFY: core/.env.example (document the STT block + "separate key" note)
+
+Task 2: ext_for_mime helper (if not already exposed)
+  - MODIFY/CONFIRM: core/app/core/storage.py exposes mime→ext (reuse the audio/ogg
+    map at ~36); add a small ext_for_mime(mime) accessor if missing
+
+Task 3: Transcription service
+  - CREATE: core/app/services/transcription.py (stt_enabled, transcribe)
+
+Task 4: Orchestrator wiring
+  - MODIFY: core/app/services/orchestrator.py
+    * add _transcribe_if_needed(inbound, caps)
+    * call it in run_turn and run_coalesced_turn (compute caps once)
+    * update _current_message audio else-branch to render a transcript
+
+Task 5: Startup sanity
+  - MODIFY: core/app/main.py (lifespan) — if stt_provider set but stt_api_key
+    empty (or base_url unresolved), log a clear WARNING that STT is effectively
+    disabled. Do not crash.
+
+Task 6: Tests (see Validation Loop)
+
+Task 7: Docs + ADR
+  - CREATE: docs/design/adr-010-stt-audio-fallback.md  [done with this PRP]
+  - MODIFY: docs/ARCHITECTURE.md (audio handling: native → STT → graceful)
+  - MODIFY: core/AGENTS.md (+ symlinked CLAUDE.md) media/orchestrator notes,
+    README env table
+
+Task 8 (cross-repo): CLI wizard opt-in  → file cli#N
+  - Add a wizard question "Enable speech-to-text for voice notes (LLMs without
+    native audio)?" → writes STT_PROVIDER/STT_MODEL/STT_API_KEY to core/.env.
+  - Default suggestion groq + whisper-large-v3-turbo. Mirrors cli#1 provisioning.
+  - Skills: note STT in the chasqui-cli skill env table (sibling skills repo).
+```
+
+---
+
+## Validation Loop
+
+### Level 0: Provider gate (manual, once)
+```bash
+# Capture a real voice note from WhatsApp/Telegram (audio/ogg, Opus) as voice.ogg
+curl -s https://api.groq.com/openai/v1/audio/transcriptions \
+  -H "Authorization: Bearer $GROQ_API_KEY" \
+  -F model=whisper-large-v3-turbo -F response_format=text -F file=@voice.ogg
+# Expect: HTTP 200 + the spoken text. Confirms native OGG (ADR-010 premise).
+```
+
+### Level 1: Core unit/integration (`cd core && uv run pytest -q`)
+```python
+# test_transcription.py / test_orchestrator_stt.py  (mock httpx, no real key)
+- stt_disabled_returns_none:
+    STT_PROVIDER="" → transcribe() returns None without any HTTP call
+- transcribe_posts_multipart_and_returns_text:
+    enabled → POSTs to {base_url}/audio/transcriptions with model+file+response_format;
+    200 text body → stripped transcript returned (httpx mocked / respx)
+- transcribe_swallows_http_error:
+    mocked 500 / timeout → returns None (no raise)
+- oversize_audio_skipped:
+    bytes > stt_max_bytes → None, no HTTP call, warning logged
+- audio_less_llm_uses_transcript:
+    caps.audio=False + STT on + audio inbound → _transcribe_if_needed sets
+    inbound.text; _current_message renders the transcript HumanMessage
+- native_audio_llm_never_transcribes:
+    caps.audio=True → _transcribe_if_needed is a no-op (no HTTP call) — audio
+    block path unchanged
+- stt_off_keeps_graceful_fallback:
+    STT_PROVIDER="" + audio + caps.audio=False → the exact "ask them to write it"
+    HumanMessage (byte-for-byte today)
+- coalesced_path_transcribes_each_audio:
+    run_coalesced_turn over a batch with an audio message → transcript present in
+    the assembled turn (media re-hydrated, mocked)
+# Hermeticity: mock transcription.transcribe / httpx — no real Groq key in CI.
+```
+
+### Level 2: Live e2e (Telegram, the cheap channel)
+```bash
+# Generated project: LLM=anthropic (caps.audio=False), STT_PROVIDER=groq,
+# STT_API_KEY set. Send a voice note in Telegram.
+# Expect: the agent answers the SPOKEN content (not "please type it").
+# Logs: "STT transcribed inbound audio (N chars)" then a normal turn.
+# Then unset STT_PROVIDER, restart → voice note → graceful "please type it".
+# Sanity: LLM=google gemini (caps.audio=True) + STT set → NO STT call (native).
+```
+
+---
+
+## Final Checklist
+- [ ] Level 0 gate passed: Groq transcribes a real WhatsApp/Telegram OGG note
+- [ ] `stt_*` settings in config + `.env.example` (separate-key note)
+- [ ] `transcription.py`: enabled-guard, multipart, best-effort (None on failure)
+- [ ] `_transcribe_if_needed` gated on `type==audio and not caps.audio and enabled`
+- [ ] Hooked in BOTH `run_turn` and `run_coalesced_turn`; caps computed once
+- [ ] `_current_message` renders a transcript; no-transcript fallback unchanged
+- [ ] STT error/timeout/oversize never breaks a turn (logged)
+- [ ] Startup warns when STT_PROVIDER set without a usable key/base_url
+- [ ] Tests green in CI (hermetic, httpx mocked); live Telegram e2e both modes
+- [ ] ADR-010 + ARCHITECTURE + READMEs/AGENTS updated; CLI wizard tracked (cli#N)
+
+---
+
+## Anti-Patterns to Avoid
+- ❌ Don't transcribe when `caps.audio` is True — native audio is better + paid-for.
+- ❌ Don't await inside the sync `_current_message` — STT is a pre-pass.
+- ❌ Don't let an STT failure raise — it must degrade to the text fallback.
+- ❌ Don't transcode OGG (no ffmpeg) — Groq takes it natively; that's why it's default.
+- ❌ Don't reuse the LLM key implicitly — STT_API_KEY is separate (LLM ≠ audio vendor).
+- ❌ Don't add the openai/groq SDK — httpx multipart is enough (already a dep).
+- ❌ Don't persist/log the audio bytes or the key — bytes are big, the key is secret.
+
+---
+
+## Notes
+
+**Default provider = Groq `whisper-large-v3-turbo` (decided 2026-06-15, ADR-010).**
+The deciding factor is **native OGG/Opus** (WhatsApp/Telegram voice) with **no
+transcoding** — which removes ffmpeg as a system dependency for an opt-in feature
+— plus the lowest cost (~$0.00067/min) and an OpenAI-compatible API so the same
+client serves OpenAI by swapping `STT_BASE_URL`. OpenRouter was rejected (empty
+transcription catalogue); Google Chirp 3 is a follow-up (GCP service-account auth
+doesn't fit `.env`-key simplicity).
+
+**Why opt-in and not on-by-default:** STT needs a second credential and is a paid
+external call. The default install stays zero-config; operators turn it on when
+their LLM can't hear and they want voice notes handled.
+
+**Transcript persistence is a deliberate follow-up** (ADR-010): storing the
+transcript in message `metadata` would let the admin timeline show what a voice
+note said. Not in this PRP — keep the change surgical.
+
+**Out of scope (future):** Google Chirp 3 adapter; ffmpeg shim (only if a future
+required provider lacks OGG); diarization; TTS for *outbound* audio (a separate,
+larger feature — this PRP is inbound STT only).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -171,6 +171,25 @@ when debounce > 0. Setting `INBOUND_DEBOUNCE_SECONDS = 0` restores the legacy
 advisory lock) serializes turns and is held in both paths. Full rationale:
 `docs/design/adr-008-deferred-dispatch-coalescing.md`.
 
+### 5.3 Audio handling: native → STT → graceful (ADR-010)
+
+An inbound voice note (`type: "audio"`) is resolved in three tiers, by the
+configured LLM's capabilities (`app/core/llm_capabilities.py`):
+
+1. **Native audio** (`caps.audio = True`, e.g. Gemini) — the audio rides into
+   the turn as a content block; the model hears it directly.
+2. **STT fallback** (`caps.audio = False` **and** `STT_PROVIDER` set) — the core
+   transcribes the audio to text **before** the turn (`app/services/transcription.py`),
+   so an audio-less LLM (Anthropic, plain OpenAI GPT, …) can still answer. The
+   transcriber is an **OpenAI-compatible** client (Groq `whisper-large-v3-turbo`
+   by default — native OGG/Opus, no transcoding); its key (`STT_API_KEY`) is
+   **separate** from the LLM's, since the LLM provider is deliberately not the
+   audio one. Opt-in and best-effort: any failure falls through to tier 3.
+3. **Graceful degradation** (no native audio, STT off/failed) — the agent is
+   told it received a voice note it can't hear and asks the user to type it.
+
+Full rationale: `docs/design/adr-010-stt-audio-fallback.md`.
+
 ## 6. Core domain model
 
 - **`contacts`** — the person on the other side. Unique by `(channel, external_id)`, where `external_id` is the **BSUID** for WhatsApp. `wa_id` is stored when available but is no longer the primary key (§10).

--- a/docs/design/adr-010-stt-audio-fallback.md
+++ b/docs/design/adr-010-stt-audio-fallback.md
@@ -1,0 +1,145 @@
+# ADR-010 — STT fallback for inbound audio (transcribe when the LLM can't hear)
+
+> **Status:** Accepted — 2026-06-15
+> **Sprint:** 12 (STT fallback) — chasqui#15
+> **Related:** ARCHITECTURE §5 (canonical contract — `audio` media), ADR-003 (media storage / re-hydration), ADR-008 (coalesced turn re-hydrates media), `app/core/llm_capabilities.py` (`caps.audio`), `app/services/orchestrator.py` (`_current_message` degradation)
+
+## Context
+
+A contact sends a **voice note**. The gateway normalizes it into the canonical
+contract as an `audio` message with the bytes inlined as a `data:` URI (ADR-003).
+What happens next depends on the configured LLM:
+
+- **Native-audio models** (Gemini — `caps.audio = True`) get the audio as a
+  content block and answer its content directly. This already works.
+- **Every other model** (Anthropic Claude, plain OpenAI GPT, most of the
+  registry — `caps.audio = False`) hits the **graceful degradation** in
+  `orchestrator._current_message`: *"[The user sent a voice message you cannot
+  listen to. Ask them to write it as text.]"* The agent politely asks the user
+  to retype. Correct, but a dead end — the user already spoke.
+
+The gap: for an audio-less LLM there is **no way to act on a voice note** even
+though transcription is a cheap, well-understood step. chasqui#15 asks for an
+**opt-in STT fallback** that transcribes the audio *before* the turn so any LLM
+can answer it as if it were text.
+
+The hard constraint is the **audio format**. WhatsApp and Telegram voice notes
+are **OGG/Opus** (confirmed: `storage.py` maps `audio/ogg`). That rules some
+providers in and out:
+
+| Provider | OGG/Opus | Cost/min | Auth | Notes |
+|----------|:---:|---|---|---|
+| OpenAI `gpt-4o-mini-transcribe` | ❌ not in supported list (`mp3,mp4,mpeg,mpga,m4a,wav,webm`) | $0.003 | API key | would need **ffmpeg** transcoding, a system dep |
+| **Groq `whisper-large-v3-turbo`** | ✅ lists `ogg` | **$0.00067** ($0.04/hr) | API key | **OpenAI-compatible** endpoint |
+| Google Chirp 3 (Cloud STT v2) | ✅ OGG_OPUS preferred | ~$0.016 | **GCP service account** | heavier auth, not a `.env` key |
+| Gemini API (`GOOGLE_API_KEY`) | ⚠️ OGG **Vorbis** only, Opus unconfirmed | cheap | reuse key | risky for voice notes (Opus) |
+| OpenRouter (transcription) | — | — | — | catalogue **empty** — not viable |
+
+## Decision
+
+### 1. STT is an opt-in fallback, gated on `caps.audio = False`
+
+Native audio is always preferred. The STT step runs **only** when the LLM lacks
+native audio input (`caps.audio = False`) **and** STT is configured. A
+native-audio model (Gemini) never transcribes — its path is byte-for-byte
+unchanged. STT unconfigured or failing → the existing graceful "ask for text"
+fallback, unchanged. **STT never breaks a turn.**
+
+### 2. One OpenAI-compatible transcription client; **Groq is the default**
+
+The `POST /v1/audio/transcriptions` multipart shape is a **de-facto standard** —
+OpenAI **and** Groq implement it identically. So the core ships **one** client
+(`app/services/transcription.py`, `httpx` multipart — already a dependency, no
+SDK) with a configurable `base_url`, and **any** compatible host works by setting
+three env vars. No provider-specific code.
+
+The default is **Groq `whisper-large-v3-turbo`** because it:
+
+- accepts **OGG/Opus natively** → kills the #1 risk (no ffmpeg, no transcoding,
+  no system dependency for an opt-in feature),
+- is the **cheapest** option (~$0.00067/min, ~4.5× cheaper than OpenAI mini),
+- is fast, and OpenAI-compatible (drop-in).
+
+OpenAI is a documented alternative (same client, `STT_BASE_URL=https://api.openai.com/v1`,
+`STT_MODEL=gpt-4o-mini-transcribe`) — with the caveat that OGG is not in OpenAI's
+supported list, so it suits deployments whose audio is already a supported format
+or that accept the `whisper-1` legacy path.
+
+### 3. The STT credential is **separate** from the LLM credential
+
+The entire use case is *"my LLM can't hear"* — i.e. the LLM provider is **not**
+the audio provider. So STT gets its **own** `STT_API_KEY`, decoupled from
+`LLM_PROVIDER`/`*_API_KEY`. It is required when STT is enabled; there is no
+implicit fallback to the LLM key (they're usually different vendors — e.g.
+Anthropic LLM + Groq STT).
+
+### 4. Config surface (all `.env`, opt-in)
+
+```bash
+STT_PROVIDER=            # "" = disabled (default) | groq | openai | <compatible>
+STT_BASE_URL=            # optional; default derived from provider
+STT_MODEL=whisper-large-v3-turbo
+STT_API_KEY=             # required when enabled; separate from the LLM key
+STT_LANGUAGE=            # optional ISO-639-1 hint; empty = auto-detect
+STT_TIMEOUT_SECONDS=30
+```
+
+`STT_PROVIDER` empty ⇒ disabled ⇒ today's behavior exactly. Provider→base_url
+defaults: `groq` → `https://api.groq.com/openai/v1`, `openai` →
+`https://api.openai.com/v1`; an explicit `STT_BASE_URL` overrides both.
+
+### 5. The transcript is rendered as a voice-message turn (no media block)
+
+When STT succeeds, the inbound's text is set to the transcript and the audio
+branch renders a normal `HumanMessage` that *tells the model it was a voice
+message* (so tone matches) **without** an audio content block — the LLM can't
+take one anyway. Both turn paths funnel through `_current_message`, so the
+synchronous turn and the coalesced turn (ADR-008, which re-hydrates media from
+the bucket) get STT identically.
+
+## Consequences
+
+**Positive**
+- Voice notes become first-class for **any** LLM, not just Gemini — opt-in.
+- Native-OGG default means **zero new system dependencies** (no ffmpeg).
+- One client serves OpenAI/Groq/any compatible host; swapping providers is three
+  env vars. No vendor lock.
+- Cheapest viable provider as the default; cost is negligible for voice notes.
+- Graceful degradation preserved: off or failing → exactly today's behavior.
+
+**Negative / trade-offs**
+- Adds an external call (and its latency, ~hundreds of ms) **before** the turn,
+  only on audio + audio-less LLM + STT enabled. Bounded by `STT_TIMEOUT_SECONDS`;
+  on timeout/error → text fallback.
+- A second credential to manage (`STT_API_KEY`) when enabled.
+- 25 MB request cap (Groq free tier); voice notes are far under it, but a guard +
+  log is needed for the pathological case.
+- Transcription quality is the provider's; mis-hears are possible. Acceptable —
+  the alternative today is *nothing*.
+
+## Alternatives considered
+
+- **OpenAI `gpt-4o-mini-transcribe` as default** — rejected as default: OGG isn't
+  in its supported formats, forcing an **ffmpeg** transcoding step (a system dep)
+  for an opt-in feature. Kept as a selectable provider for already-supported
+  formats.
+- **ffmpeg transcoding (ogg→wav) in the core** — rejected: a native-OGG provider
+  (Groq) removes the need entirely; shipping ffmpeg for an optional path is
+  disproportionate. (Re-open only if a future required provider lacks OGG.)
+- **Google Chirp 3 (Cloud STT v2)** — best OGG/Opus + multilingual, but auth is a
+  GCP **service-account JSON**, which breaks the stack's "drop an API key in
+  `.env`" simplicity. A clean **follow-up** as a dedicated provider adapter.
+- **Gemini API via `GOOGLE_API_KEY`** — tempting (reuse an existing key) but its
+  audio support lists OGG **Vorbis**, not Opus; voice notes are Opus. Too risky
+  to default to.
+- **OpenRouter transcription** — rejected: the transcription model catalogue is
+  empty; not a viable path today.
+
+## Follow-ups (out of scope)
+
+- **Google Chirp 3 provider adapter** (service-account auth) for premium
+  multilingual accuracy.
+- **ffmpeg transcoding shim** — only if a future required provider lacks OGG.
+- **Transcript persistence** — store the transcript in message `metadata` so the
+  admin timeline shows what a voice note said (today it shows `has_media`).
+- **Per-language model routing / diarization** (e.g. `gpt-4o-transcribe-diarize`).


### PR DESCRIPTION
## What

Plans **chasqui#15** — an opt-in **speech-to-text fallback** so an LLM that can't hear (`caps.audio=False`: Anthropic, plain OpenAI GPT, most of the registry) can still answer a **voice note**. Today that case dead-ends in a graceful *"please type it"* fallback; native-audio models (Gemini) are unaffected.

### ADR-010 — the decisions
1. **Opt-in, gated on `caps.audio=False`.** Gemini never transcribes (native audio is better + paid-for). Disabled/failing → today's graceful fallback, unchanged. STT never breaks a turn.
2. **One OpenAI-compatible client; Groq `whisper-large-v3-turbo` default.** Native **OGG/Opus** (WhatsApp/Telegram voice) → **no ffmpeg/transcoding**, cheapest (~$0.00067/min). OpenAI selectable via `STT_BASE_URL`.
3. **Separate `STT_API_KEY`** — the use case is LLM ≠ audio vendor.
4. Full `.env` surface; transcript rendered as a voice-message turn (no audio block).

Rejected: OpenRouter (empty transcription catalogue), Google Chirp 3 (GCP service-account auth — follow-up), Gemini key (OGG Vorbis ≠ Opus).

### PRP sprint-12 (confidence 8/10)
- **Task 0 = gate**: `curl` a real OGG voice note to Groq *before* coding (validates the native-OGG premise).
- `app/services/transcription.py` (httpx multipart, best-effort → `None` on failure, no new SDK).
- `_transcribe_if_needed` pre-pass in **both** `run_turn` and `run_coalesced_turn`; `_current_message` renders the transcript.
- Hermetic tests (httpx mocked) + live Telegram e2e in both modes.

## Files
- `docs/design/adr-010-stt-audio-fallback.md`
- `PRPs/sprint-12-stt-fallback.md`

Code lands in the `core` submodule in a follow-up PR. Closes #15 (on merge of the code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)