### PR TITLE
docs: tidy ARCHITECTURE §12 roadmap (Telegram shipped, Postgres worker)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -344,5 +344,5 @@ cd admin && npm install && npm run dev
 
 - **Web channel** (e.g. a logged-in web agent) — a new adapter + an SSR frontend where streaming/SSR earn their place.
 - Semi-generic **"customer-defined collection + retriever"** module.
-- Additional channel adapters (Telegram, Instagram).
-- Background workers / queues (`arq` / Celery) only when needed — FastAPI background tasks until then.
+- Additional channel adapters (Instagram, web widget, …). *(Telegram shipped in v0.2.0, ADR-006.)*
+- Broker-backed workers / queues (`arq` / Celery) only if the Postgres-backed worker outgrows the DB — Postgres is the queue today (ADR-002, ADR-008's deferred-dispatch worker).


### PR DESCRIPTION
Minor hygiene on the post-v1 roadmap:

- **Telegram** is no longer a future adapter — it shipped in v0.2.0 (ADR-006). Moved it out of the list with a note.
- **Background workers** line refreshed: the deferred-dispatch worker (ADR-008) made **Postgres the queue**, so a broker (`arq`/Celery) is "only if the Postgres-backed worker outgrows the DB", not "until then".

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)